### PR TITLE
fix: zoom tranform

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,24 @@
 "use client"
-// Example Usage
-import React, { useState } from "react"
+import React, { useState, useRef } from "react"
 import { useMouseMatrixTransform } from "../index"
-export default () => {
-  const { ref, applyTransformToPoint, transform, cancelDrag } =
-    useMouseMatrixTransform()
-  const [offCenter, setOffCenter] = useState(false)
+import { toString as transformToString } from "transformation-matrix"
 
-  const { x: left, y: top } = applyTransformToPoint({ x: 100, y: 100 }) as any
-  // console.log(transform, left, top)
+export default () => {
+  const svgDivRef = useRef<HTMLDivElement>(null)
+  const { ref, cancelDrag } = useMouseMatrixTransform({
+    onSetTransform(transform) {
+      if (svgDivRef.current) {
+        svgDivRef.current.style.transform = transformToString(transform)
+      }
+    },
+  })
+
+  const [offCenter, setOffCenter] = useState(false)
 
   return (
     <div style={{ height: 2000 }}>
       <div
-        ref={ref}
+        ref={ref as React.RefObject<HTMLDivElement>}
         style={{
           marginTop: offCenter ? 400 : 0,
           marginLeft: offCenter ? 400 : 0,
@@ -22,24 +27,28 @@ export default () => {
           height: 600,
           width: 600,
           overflow: "hidden",
+          cursor: "grab",
         }}
       >
         <div
+          ref={svgDivRef}
           style={{
             position: "absolute",
-            left,
-            top,
-            width: 25 * transform.d,
-            height: 25 * transform.d,
+            left: 0,
+            top: 0,
+            width: 25,
+            height: 25,
             backgroundColor: "red",
+            pointerEvents: "none",
+            transformOrigin: "0 0",
           }}
         ></div>
         <div
           style={{
             position: "absolute",
-            left: left + 400,
-            top: top + 100,
             padding: 8,
+            right: 0,
+            bottom: 0,
             color: "white",
             cursor: "pointer",
             backgroundColor: "blue",


### PR DESCRIPTION
fixes: #2, as referenced [here](https://github.com/seveibar/use-mouse-matrix-transform/issues/2#issuecomment-2466063441),

> Hey @seveibar, I've worked around the issue and have tried to reproduce the same. Here's the workaround
> https://github.com/user-attachments/assets/e99f537a-f085-443a-beac-de72f66796df
>  
> But, there is an issue with stylings, it seems to be when the top and left values are increased (i.e., offset), causing the zoom to behave incorrectly. This could be happening because the inner div is positioned absolutely within a parent container that has additional offsets (like marginTop or marginLeft). I've tried implementing the same to issue [here](https://github.com/tscircuit/snippets/issues/175), by creating a temporary file and it's working well.
> 
> is it good to raise a pr for now?

